### PR TITLE
Add new content types: Mermaid, Marp slides, Jupyter Notebooks

### DIFF
--- a/topic-11-new-content-types/topic.md
+++ b/topic-11-new-content-types/topic.md
@@ -1,0 +1,8 @@
+---
+icon:
+  type: mdi:new-box
+  color: success
+---
+# New Content Types
+
+Mermaid Diagrams, Marp Slides and Jupyter Notebooks

--- a/topic-11-new-content-types/unit-1/main-unit.md
+++ b/topic-11-new-content-types/unit-1/main-unit.md
@@ -1,0 +1,1 @@
+Mermaid Diagrams

--- a/topic-11-new-content-types/unit-1/note-mermaid/note.md
+++ b/topic-11-new-content-types/unit-1/note-mermaid/note.md
@@ -1,0 +1,152 @@
+# Mermaid Diagrams
+
+Tutors supports [Mermaid.js](https://mermaid.js.org/) diagrams directly in markdown content. Use standard fenced code blocks with the `mermaid` language identifier.
+
+## Flowchart
+
+```mermaid
+flowchart TD
+    A[Student visits course] --> B{Authenticated?}
+    B -->|Yes| C[Load dashboard]
+    B -->|No| D[Show public content]
+    C --> E[Track progress]
+    D --> F[Browse topics]
+    E --> F
+    F --> G[Open learning object]
+    G --> H{Type?}
+    H -->|Lab| I[Step-by-step instructions]
+    H -->|Talk| J[PDF slides]
+    H -->|Note| K[Markdown content]
+    H -->|Notebook| L[Interactive Python]
+```
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant S as Student
+    participant T as Tutors Reader
+    participant API as Course API
+    participant DB as Supabase
+
+    S->>T: Visit course URL
+    T->>API: Fetch tutors.json
+    API-->>T: Course data
+    T->>T: Build learning object tree
+    T-->>S: Render course view
+    S->>T: Navigate to lab
+    T->>T: Convert markdown to HTML
+    T-->>S: Display lab step
+    S->>DB: Record time on task
+```
+
+## Class Diagram
+
+```mermaid
+classDiagram
+    class Lo {
+        +string type
+        +string title
+        +string summary
+        +string route
+        +string img
+        +Lo[] los
+    }
+    class Lab {
+        +Lo[] los
+        +string type = "lab"
+    }
+    class Note {
+        +string contentHtml
+        +string type = "note"
+    }
+    class Notebook {
+        +NotebookCell[] cells
+        +string kernelLanguage
+        +string type = "notebook"
+    }
+    class Talk {
+        +string pdf
+        +string type = "talk"
+    }
+    Lo <|-- Lab
+    Lo <|-- Note
+    Lo <|-- Notebook
+    Lo <|-- Talk
+```
+
+## State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Browsing
+    Browsing --> Authenticated: Sign in
+    Authenticated --> Browsing: Sign out
+    Browsing --> ViewingTopic: Select topic
+    ViewingTopic --> ViewingLab: Open lab
+    ViewingLab --> ViewingStep: Navigate steps
+    ViewingStep --> ViewingLab: Back to lab
+    ViewingLab --> ViewingTopic: Back to topic
+    ViewingTopic --> Browsing: Back to course
+```
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    COURSE ||--o{ TOPIC : contains
+    TOPIC ||--o{ UNIT : contains
+    UNIT ||--o{ LAB : contains
+    UNIT ||--o{ TALK : contains
+    UNIT ||--o{ NOTE : contains
+    UNIT ||--o{ NOTEBOOK : contains
+    LAB ||--o{ STEP : contains
+    NOTEBOOK ||--o{ CELL : contains
+    CELL {
+        string cellType
+        string source
+        string outputsHtml
+    }
+```
+
+## Gantt Chart
+
+```mermaid
+gantt
+    title Course Development Timeline
+    dateFormat YYYY-MM-DD
+    section Content
+        Write labs           :a1, 2024-01-01, 30d
+        Create talks         :a2, after a1, 20d
+        Add notebooks        :a3, after a2, 15d
+    section Review
+        Peer review          :b1, after a3, 10d
+        Student testing      :b2, after b1, 14d
+    section Deploy
+        Generate JSON        :c1, after b2, 2d
+        Deploy to Netlify    :c2, after c1, 1d
+```
+
+## Pie Chart
+
+```mermaid
+pie title Content Types in a Typical Course
+    "Labs" : 40
+    "Talks" : 25
+    "Notes" : 15
+    "Notebooks" : 10
+    "Videos" : 10
+```
+
+## Usage
+
+To include a Mermaid diagram in any note, lab step, or panel note, simply use a fenced code block:
+
+~~~
+```mermaid
+flowchart LR
+    A --> B --> C
+```
+~~~
+
+Mermaid diagrams are rendered client-side and support all standard Mermaid diagram types including flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, and more.

--- a/topic-11-new-content-types/unit-2/main-unit.md
+++ b/topic-11-new-content-types/unit-2/main-unit.md
@@ -1,0 +1,1 @@
+Marp Slides

--- a/topic-11-new-content-types/unit-2/talk-marp/talk-marp.marp
+++ b/topic-11-new-content-types/unit-2/talk-marp/talk-marp.marp
@@ -1,0 +1,116 @@
+---
+marp: true
+theme: default
+paginate: true
+---
+
+# Introduction to Tutors
+
+### An Open Learning Web Toolkit
+
+---
+
+## What is Tutors?
+
+- Open source learning platform
+- Markdown-driven course authoring
+- Rich content types: labs, talks, notes, notebooks
+- Real-time student presence and analytics
+
+---
+
+## Course Structure
+
+A Tutors course is organised as:
+
+```
+course/
+  topic-01/
+    unit-1/
+      lab-intro/        # Step-by-step lab
+      talk-overview/    # PDF or Marp slides
+      note-summary/     # Markdown note
+      notebook-demo/    # Jupyter notebook
+```
+
+---
+
+## Content Types
+
+| Type | Format | Use Case |
+|------|--------|----------|
+| **Lab** | Markdown steps | Hands-on exercises |
+| **Talk** | PDF / Marp | Lecture slides |
+| **Note** | Markdown | Reference material |
+| **Notebook** | .ipynb | Interactive coding |
+
+---
+
+## Labs
+
+Labs are step-by-step markdown documents:
+
+- Each file becomes a navigable step
+- Supports code highlighting, images, and LaTeX
+- Arrow key navigation between steps
+- Auto-numbering of steps (optional)
+
+---
+
+## Talks with Marp
+
+This presentation is written in **Marp** format:
+
+- Simple markdown with `---` slide separators
+- Themes and pagination built-in
+- No PDF conversion needed
+- Lives alongside your course content
+
+---
+
+## Jupyter Notebooks
+
+Notebooks bring interactive coding to Tutors:
+
+- Python, R, Julia and more
+- Code cells with outputs
+- Click-to-reveal output pattern
+- Rendered from standard `.ipynb` files
+
+---
+
+## Mermaid Diagrams
+
+Diagrams rendered directly from markdown:
+
+```mermaid
+flowchart LR
+    Author -->|writes| Markdown
+    Markdown -->|generates| JSON
+    JSON -->|renders| Tutors
+```
+
+---
+
+## Getting Started
+
+1. Create a course folder with `course.md` and `properties.yaml`
+2. Add topics and units following naming conventions
+3. Run the Tutors generator CLI
+4. Deploy the generated `json/` folder
+
+---
+
+## Learn More
+
+- **Documentation**: [tutors.dev](https://tutors.dev)
+- **Source**: [github.com/tutors-sdk](https://github.com/tutors-sdk)
+- **Reference Course**: This course!
+
+---
+
+<!-- _class: lead -->
+
+# Thank You
+
+### Questions?

--- a/topic-11-new-content-types/unit-2/talk-marp/talk-marp.md
+++ b/topic-11-new-content-types/unit-2/talk-marp/talk-marp.md
@@ -1,0 +1,3 @@
+# Marp Slides
+
+An example of Marp-powered slides as a talk alternative.

--- a/topic-11-new-content-types/unit-3/main-unit.md
+++ b/topic-11-new-content-types/unit-3/main-unit.md
@@ -1,0 +1,1 @@
+Jupyter Notebooks

--- a/topic-11-new-content-types/unit-3/notebook-python-intro/notebook-python-intro.md
+++ b/topic-11-new-content-types/unit-3/notebook-python-intro/notebook-python-intro.md
@@ -1,0 +1,3 @@
+# Python Basics Notebook
+
+An interactive Jupyter Notebook demonstrating Python fundamentals.

--- a/topic-11-new-content-types/unit-3/notebook-python-intro/python-basics.ipynb
+++ b/topic-11-new-content-types/unit-3/notebook-python-intro/python-basics.ipynb
@@ -1,0 +1,313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-intro",
+   "metadata": {},
+   "source": [
+    "# Python Basics\n",
+    "\n",
+    "This notebook covers fundamental Python concepts.\n",
+    "\n",
+    "## What you'll learn\n",
+    "\n",
+    "- Variables and data types\n",
+    "- Working with lists\n",
+    "- Functions and control flow\n",
+    "- String formatting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-variables-heading",
+   "metadata": {},
+   "source": [
+    "## Variables and Data Types\n",
+    "\n",
+    "Python supports several built-in data types. Let's explore the most common ones."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-variables",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Name: Tutors Platform\n",
+      "Version: 15.0\n",
+      "Active: True\n",
+      "Features: labs, talks, notes, notebooks\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Basic variable assignment\n",
+    "name = \"Tutors Platform\"\n",
+    "version = 15.0\n",
+    "is_active = True\n",
+    "features = [\"labs\", \"talks\", \"notes\", \"notebooks\"]\n",
+    "\n",
+    "print(f\"Name: {name}\")\n",
+    "print(f\"Version: {version}\")\n",
+    "print(f\"Active: {is_active}\")\n",
+    "print(f\"Features: {', '.join(features)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-lists-heading",
+   "metadata": {},
+   "source": [
+    "## Working with Lists\n",
+    "\n",
+    "Lists are ordered, mutable collections. They're one of the most versatile data structures in Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-lists",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scores: [85, 92, 78, 95, 88]\n",
+      "Average: 87.6\n",
+      "Highest: 95\n",
+      "Lowest: 78\n",
+      "Sorted: [78, 85, 88, 92, 95]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# List operations\n",
+    "scores = [85, 92, 78, 95, 88]\n",
+    "\n",
+    "print(f\"Scores: {scores}\")\n",
+    "print(f\"Average: {sum(scores) / len(scores)}\")\n",
+    "print(f\"Highest: {max(scores)}\")\n",
+    "print(f\"Lowest: {min(scores)}\")\n",
+    "print(f\"Sorted: {sorted(scores)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-functions-heading",
+   "metadata": {},
+   "source": [
+    "## Functions\n",
+    "\n",
+    "Functions let you organize and reuse code. Python uses the `def` keyword."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-functions",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice: B (82.5)\n",
+      "Bob: A (91.0)\n",
+      "Charlie: C (74.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def calculate_grade(scores):\n",
+    "    \"\"\"Calculate letter grade from a list of scores.\"\"\"\n",
+    "    average = sum(scores) / len(scores)\n",
+    "    if average >= 90:\n",
+    "        return \"A\", average\n",
+    "    elif average >= 80:\n",
+    "        return \"B\", average\n",
+    "    elif average >= 70:\n",
+    "        return \"C\", average\n",
+    "    elif average >= 60:\n",
+    "        return \"D\", average\n",
+    "    else:\n",
+    "        return \"F\", average\n",
+    "\n",
+    "students = {\n",
+    "    \"Alice\": [85, 78, 92, 75],\n",
+    "    \"Bob\": [95, 88, 91, 90],\n",
+    "    \"Charlie\": [72, 68, 80, 76]\n",
+    "}\n",
+    "\n",
+    "for name, scores in students.items():\n",
+    "    grade, avg = calculate_grade(scores)\n",
+    "    print(f\"{name}: {grade} ({avg})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-comprehensions-heading",
+   "metadata": {},
+   "source": [
+    "## List Comprehensions\n",
+    "\n",
+    "A concise way to create lists based on existing sequences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-comprehensions",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Squares: [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n",
+      "Even squares: [4, 16, 36, 64, 100]\n",
+      "Word lengths: {'hello': 5, 'world': 5, 'python': 6, 'tutors': 6}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# List comprehension examples\n",
+    "squares = [x**2 for x in range(1, 11)]\n",
+    "print(f\"Squares: {squares}\")\n",
+    "\n",
+    "even_squares = [x**2 for x in range(1, 11) if x % 2 == 0]\n",
+    "print(f\"Even squares: {even_squares}\")\n",
+    "\n",
+    "# Dictionary comprehension\n",
+    "words = [\"hello\", \"world\", \"python\", \"tutors\"]\n",
+    "word_lengths = {w: len(w) for w in words}\n",
+    "print(f\"Word lengths: {word_lengths}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-error-heading",
+   "metadata": {},
+   "source": [
+    "## Error Handling\n",
+    "\n",
+    "Python uses `try`/`except` blocks to handle errors gracefully."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-error",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 / 3 = 3.33\n",
+      "10 / 0 = Cannot divide by zero!\n",
+      "10 / a = Invalid input: could not convert string to float: 'a'\n"
+     ]
+    }
+   ],
+   "source": [
+    "def safe_divide(a, b):\n",
+    "    \"\"\"Safely divide two numbers with error handling.\"\"\"\n",
+    "    try:\n",
+    "        result = float(a) / float(b)\n",
+    "        return f\"{result:.2f}\"\n",
+    "    except ZeroDivisionError:\n",
+    "        return \"Cannot divide by zero!\"\n",
+    "    except ValueError as e:\n",
+    "        return f\"Invalid input: {e}\"\n",
+    "\n",
+    "print(f\"10 / 3 = {safe_divide(10, 3)}\")\n",
+    "print(f\"10 / 0 = {safe_divide(10, 0)}\")\n",
+    "print(f\"10 / a = {safe_divide(10, 'a')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-math-heading",
+   "metadata": {},
+   "source": [
+    "## Mathematical Notation\n",
+    "\n",
+    "Notebooks support LaTeX for mathematical expressions:\n",
+    "\n",
+    "The quadratic formula: $x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$\n",
+    "\n",
+    "Let's implement it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-math",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solving: 1x² + -5x + 6 = 0\n",
+      "Solutions: x = 3.0 and x = 2.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "\n",
+    "def quadratic(a, b, c):\n",
+    "    \"\"\"Solve ax² + bx + c = 0 using the quadratic formula.\"\"\"\n",
+    "    discriminant = b**2 - 4*a*c\n",
+    "    if discriminant < 0:\n",
+    "        return None, None\n",
+    "    x1 = (-b + math.sqrt(discriminant)) / (2*a)\n",
+    "    x2 = (-b - math.sqrt(discriminant)) / (2*a)\n",
+    "    return x1, x2\n",
+    "\n",
+    "a, b, c = 1, -5, 6\n",
+    "x1, x2 = quadratic(a, b, c)\n",
+    "print(f\"Solving: {a}x\\u00b2 + {b}x + {c} = 0\")\n",
+    "print(f\"Solutions: x = {x1} and x = {x2}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-summary",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we covered:\n",
+    "\n",
+    "1. **Variables** — strings, numbers, booleans, lists\n",
+    "2. **Lists** — operations, sorting, aggregation\n",
+    "3. **Functions** — definition, return values, real-world usage\n",
+    "4. **Comprehensions** — list and dictionary comprehensions\n",
+    "5. **Error handling** — try/except patterns\n",
+    "6. **Math** — the quadratic formula with LaTeX notation\n",
+    "\n",
+    "> **Next steps:** Try modifying the code cells above and experimenting!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds a new **topic-11** showcasing three new Tutors content types:

- **Mermaid diagrams** — note with 7 diagram types (flowchart, sequence, class, state, ER, gantt, pie) plus usage instructions
- **Marp slides** — talk using `.marp` format as a PDF-free slide alternative, 12-slide deck covering Tutors features
- **Jupyter Notebook** — interactive Python basics notebook with 6 code cells covering variables, lists, functions, comprehensions, error handling, and math

## Companion PRs

This reference course content requires the following PRs to be merged first:

- **Reader — Mermaid + Marp**: https://github.com/tutors-sdk/tutors/pull/1063
- **Reader — Jupyter Notebook**: https://github.com/tutors-sdk/tutors/pull/1064
- **Generator — Jupyter Notebook**: https://github.com/tutors-sdk/tutors-apps/pull/13

## Test plan

- [ ] Generate this course with the updated generator CLI
- [ ] Verify Mermaid diagrams render in the note view
- [ ] Verify Marp slides render as navigable slides in the talk view
- [ ] Verify Jupyter Notebook renders with click-to-reveal outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)