### PR TITLE
Add quiz learning object example

### DIFF
--- a/topic-01-typical/unit-2/quiz-basics/quiz.md
+++ b/topic-01-typical/unit-2/quiz-basics/quiz.md
@@ -1,0 +1,24 @@
+title: "Course Concepts Quiz"
+time_limit: 30
+---
+type: multiple-choice
+text: "Which learning object type allows live, real-time participation?"
+options:
+- "Note"
+- "Lab"  
+- "Quiz"
+- "Talk"
+correct: 2
+---
+type: multiple-choice
+text: "What file defines a quiz in Tutors?"
+options:
+- "quiz.json"
+- "quiz.md"
+- "quiz.yaml"
+- "quiz.html"
+correct: 1
+---
+type: true-false
+text: "Tutors supports both live and asynchronous quizzes"
+correct: true


### PR DESCRIPTION
## Summary
- Adds a `quiz-basics` folder demonstrating the `quiz.md` format
- Includes multiple-choice and true-false question examples
- Part of the quiz learning object feature series

## Related PRs (quiz feature series)
1. **tutors reader**: https://github.com/tutors-sdk/tutors/pull/1093 — quiz UI, services, and routes
2. **tutors-apps**: https://github.com/tutors-sdk/tutors-apps/pull/18 — model-lib quiz type recognition
3. **tutors-reference-course** (this PR): https://github.com/tutors-sdk/tutors-reference-course/pull/3

## Test plan
- [ ] Run tutors CLI against this course after tutors-apps quiz support lands
- [ ] Verify quiz renders correctly in Tutors reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)